### PR TITLE
Replaced ListItemHelper with ListItemClass

### DIFF
--- a/src/components/Sidebar/ClippedSideBar.js
+++ b/src/components/Sidebar/ClippedSideBar.js
@@ -6,8 +6,9 @@ import CssBaseline from '@mui/material/CssBaseline';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
-import ListItemHelper from "./ListItemHelper"
+// import ListItemHelper from "./ListItemHelper"
 import PrimalJetLogo from "./resizedLogo.png"
+import ListItemClass from "./ListItemClass"
 
 const drawerWidth = 240;
 
@@ -33,13 +34,13 @@ export default function ClippedDrawer() {
       >
         <Toolbar />
         <Box sx={{ overflow: 'auto' }}>
-            {ListItemHelper(1)}
-            {ListItemHelper(2)}
-            {ListItemHelper(3)}
-            {ListItemHelper(4)}
+            <ListItemClass id={1} />
+            <ListItemClass id={2} />
+            <ListItemClass id={3} />
+            <ListItemClass id={4} />
             <Divider />
-            {ListItemHelper(5)}
-            {ListItemHelper(6)}
+            <ListItemClass id={5} />
+            <ListItemClass id={6} />
         </Box>
       </Drawer>
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>

--- a/src/components/Sidebar/ListItemClass.js
+++ b/src/components/Sidebar/ListItemClass.js
@@ -1,0 +1,28 @@
+import React from "react";
+import IconHelper from "./IconHelper"
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import TextHelper from "./TextHelper"
+
+export default class ListItemClass extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {id: props.id};
+    }
+    render() {
+        return (
+            <div>
+                <List>
+                    <ListItem button>
+                        <ListItemIcon>
+                            {IconHelper(this.state.id)}
+                        </ListItemIcon>
+                        <ListItemText primary={TextHelper(this.state.id)}/>
+                    </ListItem>
+                </List>
+            </div>
+        );
+    }
+}


### PR DESCRIPTION
Created a ListItemClass that uses props instead of an index value passed through a function. Later on, this will be useful with working with events, as we can process database values as prop values to individual events.

I converted the sidebar list item component from a function to a class 

Later on, I foresee that we will need to create an Event class so that we can use props and render a sidebar button and card component that is unique to each and every event in the database.
Event Class will probably need: 
props.name
props.id
props.date
props.icon (i think we can give the user options to set an icon for the event using pre-determined icons, and we will need database values/api endpoints for this)
props.users (props.hosts/props.guests) 

It's definitely gonna get annoying if we have to pass through each value we want instead of just passing in props for each front-end component that uses it (Card, Sidebar, Create/Edit, To-Do, View More, etc.) 
Props is hella useful because not every function needs to know the name, id, date, but other functions need all the data, and it'll get messy if you have to memorize each function's parameters, whereas if we pass props that's it and each function can get its data accordingly
Oh and with this change, I think TextHelper will become obsolete because we could just render props.name as a string
